### PR TITLE
Add reset for custom parts window animation

### DIFF
--- a/EditBodyLoadFix.cs
+++ b/EditBodyLoadFix.cs
@@ -34,6 +34,7 @@ namespace COM3D2.EditBodyLoadFix {
 			yield return new WaitForSeconds(0.5f);
 			ResetPose();
 			ResetParts(maid);
+			ResetCustomPartsEdit(maid);
 		}
 
 		static void ResetPose() {
@@ -50,6 +51,11 @@ namespace COM3D2.EditBodyLoadFix {
 					maid.body0.BoneMorph_FromProcItem(maidProp.name, maidProp.value / 100f);
 				}
 			}
+		}
+
+		static void ResetCustomPartsEdit(Maid maid) {
+			AccessTools.Field(typeof(CustomPartsWindow), "animation")
+				.SetValue(SceneEdit.Instance.customPartsWindow, maid.GetAnimation());
 		}
 
 		[HarmonyPatch(typeof(CharacterMgr), "PresetSet", typeof(Maid), typeof(CharacterMgr.Preset))]


### PR DESCRIPTION
This fixes an issue where custom accessory placement does not pause the maid animation after changing the maid's body which makes placing the accessory very difficult.