### PR TITLE
Add resetting touch jump feature and resetting grabbing the maid in VR

### DIFF
--- a/COM3D2.EditBodyLoadFix.csproj
+++ b/COM3D2.EditBodyLoadFix.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net35</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RepositoryUrl>https://github.com/Perdition-51/COM3D2.EditBodyLoadFix</RepositoryUrl>
     <Authors>Perdition</Authors>
   </PropertyGroup>

--- a/EditBodyLoadFix.cs
+++ b/EditBodyLoadFix.cs
@@ -54,8 +54,7 @@ namespace COM3D2.EditBodyLoadFix {
 		}
 
 		static void ResetCustomPartsEdit(Maid maid) {
-			AccessTools.Field(typeof(CustomPartsWindow), "animation")
-				.SetValue(SceneEdit.Instance.customPartsWindow, maid.GetAnimation());
+			SceneEdit.Instance.customPartsWindow.animation = maid.GetAnimation();
 		}
 
 		[HarmonyPatch(typeof(CharacterMgr), "PresetSet", typeof(Maid), typeof(CharacterMgr.Preset))]


### PR DESCRIPTION
The mechanisms for the touch jump feature and grabbing the maid in VR are closely related so both are fixed at the same time despite the main focus of the fix being for the former.

This fix requires a publicised version of `Assembly-CSharp.dll` and `AllowUnsafeBlocks` compiler option set to `true` from here on out to compile.